### PR TITLE
Renames as prep for packaging and attempt to auto compile

### DIFF
--- a/examples/demo.jl
+++ b/examples/demo.jl
@@ -1,5 +1,6 @@
-include("lib/Julio.jl")
+## include("lib/Julio.jl")
 #using Julio
+load("Julio")
 
 # set starting parameters for the embedded R
 argv = ["Julio", "--slave"]# "--quiet"]

--- a/src/Julio.jl
+++ b/src/Julio.jl
@@ -13,7 +13,22 @@ export initr, isinitialized, isbusy, hasinitargs, setinitargs, getinitargs,
        getGlobalEnv, getBaseEnv,
        Rinenv, @R
 
-libri = dlopen("./deps/librinterface")
+       
+dllname = julia_pkgdir() * "/Julio/deps/librinterface.so"
+if !isfile(dllname)
+    println("*****************************************************")
+    println("Can't find librinterface.so; attempting to compile...")
+    println("*****************************************************")
+    cd(julia_pkgdir() * "/Julio/deps") do
+        run(`make all`) 
+    end
+    println("*****************************************************")
+    println("Compiling complete")
+    println("*****************************************************")
+end    
+
+libri = dlopen(julia_pkgdir() * "/Julio/deps/librinterface")
+
 
 function isinitialized()
     res = ccall(dlsym(libri, :EmbeddedR_isInitialized), Int32, ())


### PR DESCRIPTION
The rename from lib to src is so that `load("Julio")` can find Julio.jl when the package is in ~/.julia/Julio. You should also probably rename the github repo from julio to Julio.jl. You might want to change the name while you're at it. R.jl sounds good, and you can have an R module and an @R macro at the same time. Rcmd.jl or Rj.jl are good, too (the module names would be the same without the .jl at the end).

The auto-compile stuff is a kludge, but it may be good enough until something better is developed.
