### PR TITLE
Change name so that CentOS can find the shared object file.

### DIFF
--- a/src/embeddedr.jl
+++ b/src/embeddedr.jl
@@ -15,8 +15,7 @@ const VECSXP  = uint(19)
 const EXPRSXP = uint(20)
 const S4SXP  = uint(25)
 
-
-libri = dlopen(julia_pkgdir() * "/Rif/deps/librinterface")
+const libri = dlopen(Pkg.dir("Rif/deps/librinterface") * (OS_NAME == :Linux ? ".so" : ""))
 
 function isinitialized()
     res = ccall(dlsym(libri, :EmbeddedR_isInitialized), Int32, ())


### PR DESCRIPTION
In Linux (I use CentOS 6), `require("Rif")` fails unless I add `.so` to the shared object name call in `dlopen`.
