### PR TITLE
changed so it builds dylib instead of so shared lib file (needed on Mac)

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -4,5 +4,5 @@ CC=            gcc
 R=             R
 CPPFLAGS =     `${R} CMD config --cppflags`
 CFLAGS=        -g -Wall -DCSTACK_DEFNS -DRIF_HAS_RSIGHAND -DHAS_READLINE -fno-stack-protector
-LDFLAGS=       `${R} CMD config --ldflags`
+LDFLAGS=       `${R} CMD config --ldflags` -dynamiclib
 USE_SYSTEM_READLINE = 1


### PR DESCRIPTION
Not sure how this needs to be written so this flag only used on Mac though...
