### PR TITLE
print to stderr to avoid contaminating stdout in streaming scripts

### DIFF
--- a/src/embeddedr.jl
+++ b/src/embeddedr.jl
@@ -60,7 +60,7 @@ function initr()
         Rif.setinitargs(_default_argv)
     end
     rhome = rstrip(readall(`R RHOME`))
-    print("Using R_HOME=", rhome, "\n")
+    print(STDERR, "Using R_HOME=", rhome, "\n")
     EnvHash()["R_HOME"] = rhome
     res = ccall(dlsym(libri, :EmbeddedR_init), Int32, ())
     if res == -1


### PR DESCRIPTION
I found that some processing scripts that produced meaningful stdout would get "Using R_HOME" statements showing up the in data stream when initr() was run. I am not sure this really needs printed, but if it is printed to stderr then it is less of an issue. 
