### PR TITLE
Import 'ggplot2' for ggbio example

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ gr = r_gr.(symbol("seqlengths<-"))(gr, RArray{Int32, 1}(Int32[400, 500, 700]))
 # in the meantime the plot _is_ working
 +(x::RArray{Sexp,1}, y::RArray{Sexp,1})=r_base.(symbol("+"))(x,y)
 
+ggplot2 = importr("ggplot2")
 p = ggplot2.ggplot() + 
   ggbio.layout_circle(gr; geom = "ideo", fill = "gray70", 
                 radius = 7, trackWidth = 3) +


### PR DESCRIPTION
Without the explicit import, 'ggplot2' cannot be referenced (failing with `ERROR: ggplot2 not defined`)