### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,16 @@
-language: cpp
-compiler:
-    - gcc
-    - clang
+language: julia
+julia:
+    - 0.4
+    - 0.5
+    - nightly
 notifications:
     email: true
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-    - JULIAVERSION="julianightlies"
 before_install:
-    - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-    - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
     - sudo apt-get update -qq -y
-    - sudo apt-get install git libpcre3-dev julia r-base r-base-dev -y
-    - git config --global user.name "Travis User"
-    - git config --global user.email "travis@example.net"
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-script:
-    - julia -e 'Pkg.init(); Pkg.clone(pwd())'
-    - julia -e 'Pkg.test("Rif")'
-    - if [ $JULIAVERSION = "julianightlies" ]; then julia --code-coverage test/runtests.jl; fi
-    - if [ $JULIAVERSION = "juliareleases" ]; then julia test/runtests.jl; fi
+    - sudo apt-get install r-base r-base-dev -y
+#script: # use the default script setting which is equivalent to the following
+#    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#    - julia -e 'Pkg.init(); Pkg.clone(pwd())'
+#    - julia -e 'Pkg.test("Rif")'
+#    - if [ $JULIAVERSION = "julianightlies" ]; then julia --code-coverage test/runtests.jl; fi
+#    - if [ $JULIAVERSION = "juliareleases" ]; then julia test/runtests.jl; fi

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
+julia 0.4
 DataFrames
 Compat

--- a/src/Rif.jl
+++ b/src/Rif.jl
@@ -40,11 +40,11 @@ export initr, isinitialized, isbusy, hasinitargs, setinitargs, getinitargs,
 _do_rebuild = false
 
 @compat function _packpath(dir::AbstractString, name::AbstractString)
-    return joinpath(Pkg.dir(), "Rif", dir, name)
+    return joinpath(dirname(@__FILE__), "..", dir, name)
 end
 
 @compat function _packpath(dir::AbstractString)
-    return joinpath(Pkg.dir(), "Rif", dir)
+    return joinpath(dirname(@__FILE__), "..", dir)
 end
 
 LibRInterfaceSharedLib = @osx ? "librinterface.dylib" : "librinterface.so"

--- a/src/embeddedr.jl
+++ b/src/embeddedr.jl
@@ -16,7 +16,7 @@
 @compat const S4SXP  = UInt(25)
 
 
-libri = Libdl.dlopen(dirname(@__FILE__) * "../deps/librinterface")
+libri = Libdl.dlopen(dirname(@__FILE__) * "/../deps/librinterface")
 
 function isinitialized()
     res = ccall(dlsym(libri, :EmbeddedR_isInitialized), Int32, ())

--- a/src/embeddedr.jl
+++ b/src/embeddedr.jl
@@ -16,7 +16,7 @@
 @compat const S4SXP  = UInt(25)
 
 
-libri = Libdl.dlopen(Pkg.dir() * "/Rif/deps/librinterface")
+libri = Libdl.dlopen(dirname(@__FILE__) * "../deps/librinterface")
 
 function isinitialized()
     res = ccall(dlsym(libri, :EmbeddedR_isInitialized), Int32, ())


### PR DESCRIPTION
This allows installing the package elsewhere.

What is the minimum (and/or maximum) Julia version you intend to support here? It's not marked in the `REQUIRE` file.
